### PR TITLE
use-v2x-branch-for-catch2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests/catch2"]
 	path = tests/catch2
 	url = https://github.com/catchorg/Catch2.git
+	branch = v2.x


### PR DESCRIPTION
Master branch in catch2 doesn't exists anymore, so it needs to be changed to an existing one.